### PR TITLE
Adds source to mobile and desktop calendar.  Removes title

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -71,13 +71,13 @@
 
 					<div id="desktop-view">
 						<center>
-							<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;ctz=America%2FChicago" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+							<iframe src="https://calendar.google.com/calendar/embed?src=omahagirlswhocode%40gmail.com&showTitle=0&height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;ctz=America%2FChicago" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 						</center>
 					</div>
 
 					<div id="mobile-view">
 						<center>
-							<iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;ctz=America%2FChicago" style="border-width:0" width="450" height="600" frameborder="0" scrolling="no">
+							<iframe src="https://calendar.google.com/calendar/embed?src=omahagirlswhocode%40gmail.com&showTitle=0&amp;showNav=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;ctz=America%2FChicago" style="border-width:0" width="450" height="600" frameborder="0" scrolling="no">
 							</iframe>
 						</center>
 					</div>

--- a/calendar.html
+++ b/calendar.html
@@ -71,13 +71,13 @@
 
 					<div id="desktop-view">
 						<center>
-							<iframe src="https://calendar.google.com/calendar/embed?src=omahagirlswhocode%40gmail.com&showTitle=0&height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;ctz=America%2FChicago" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+							<iframe src="https://calendar.google.com/calendar/embed?src=mk4bmjehj8tu64dmlqqgeornvs%40group.calendar.google.com&showTitle=0&height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;ctz=America%2FChicago" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 						</center>
 					</div>
 
 					<div id="mobile-view">
 						<center>
-							<iframe src="https://calendar.google.com/calendar/embed?src=omahagirlswhocode%40gmail.com&showTitle=0&amp;showNav=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;ctz=America%2FChicago" style="border-width:0" width="450" height="600" frameborder="0" scrolling="no">
+							<iframe src="https://calendar.google.com/calendar/embed?src=mk4bmjehj8tu64dmlqqgeornvs%40group.calendar.google.com&showTitle=0&amp;showNav=0&amp;mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;ctz=America%2FChicago" style="border-width:0" width="450" height="600" frameborder="0" scrolling="no">
 							</iframe>
 						</center>
 					</div>


### PR DESCRIPTION
The previous calendar page did not link to any google calendar site.  So our omahagirlswhocode calendar event on August 13th did not show up.

Updated source tags for mobile and desktop view.

Title looked funny on desktop view.  Hid it.

@sandikbarr  @shonnadorsey Please review.
