### PR TITLE
Update clubs.html button ordering for Abrahams to match Do Space

### DIFF
--- a/clubs.html
+++ b/clubs.html
@@ -159,8 +159,8 @@
             <p><span>Instructors:</span> Eris Koleszar, Bianca Zongrone, Wendy Holley, Shannon Jackson</p>
           </div>
           <div class="col-xs-12 col-sm-4">
-            <a type="button" class="btn btn-default" data-toggle="modal" data-target="#appModal" data-tooltip="tooltip" data-placement="bottom" title="Apply Now">Apply Now</a>
             <h4>Accepting Applications</h4>
+            <a type="button" class="btn btn-default" data-toggle="modal" data-target="#appModal" data-tooltip="tooltip" data-placement="bottom" title="Apply Now">Apply Now</a>
             <p><span>Applications Due:</span> Saturday, August 27</p>
             <p><span>Session Starts:</span> Saturday, September 17</p>
           </div>


### PR DESCRIPTION
The 'Accepting Applications' text is currently under the button for Abrahams branch on clubs.html. Corrected. 
